### PR TITLE
docs: add Firebase authorized domains note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ FiremittHelper.auth(options)
 
 > You can point `url` at the hosted Fireguard instance (`https://ouss.es/fireguard`) or your own [self-hosted](https://github.com/EOussama/fireguard) deployment.
 
+> **Note:** Firebase only allows sign-in popups from authorized domains. If you are using a self-hosted Fireguard deployment, add its domain to the authorized domains list in the Firebase Console under **Authentication → Settings → Authorized domains**. Skipping this step will cause the authentication popup to be blocked.
+
 ### Configuration
 
 #### `TFiremittOptions`


### PR DESCRIPTION
## Summary

Adds a note to the **Authentication** section of the README warning users that Firebase restricts sign-in popups to authorized domains.

Closes #62

## What changed

- `README.md`: Added a blockquote note after the hosted/self-hosted URL callout explaining that self-hosted Fireguard deployments must have their domain added to the Firebase Console under **Authentication → Settings → Authorized domains**.

## Why

Without this, users who deploy their own Fireguard instance can run into a silently blocked auth popup with no obvious cause. The note surfaces this requirement at the point where users are configuring their setup, making it actionable before they hit the issue.