### PR TITLE
Popup Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "prepublishOnly": "pnpm build",
     "dev": "vite",
-    "sandbox": "vite --config playground/vite.config.js",
+    "playground": "vite --config playground/vite.config.js",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "preview": "vite preview",

--- a/playground/index.html
+++ b/playground/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Firemitt Sandbox</title>
+    <title>Firemitt Playground</title>
     <link rel="icon" href="https://raw.githubusercontent.com/eoussama/firemitt/refs/heads/main/assets/favicon.ico" />
     <style>
       *, *::before, *::after {
@@ -357,7 +357,7 @@
   <body>
     <header>
       <img src="https://raw.githubusercontent.com/eoussama/firemitt/refs/heads/main/assets/firemitt.svg" alt="Firemitt Logo" />
-      <h1>Firemitt Sandbox</h1>
+      <h1>Firemitt Playground</h1>
       <span>Edge-case testing playground</span>
     </header>
 

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -169,8 +169,8 @@ function setActiveScenario(active: HTMLButtonElement): void {
 function buildUrlPresets(): void {
   const presets = [
     { label: "Hosted", value: DEFAULT_FIREGUARD_URL },
-    { label: "localhost:3000", value: "http://localhost:3000" },
-    { label: "localhost:4000", value: "http://localhost:4000" },
+    { label: "localhost:5173", value: "http://localhost:5173" },
+    { label: "localhost:5174", value: "http://localhost:5174" },
     { label: "localhost:8080", value: "http://localhost:8080" },
   ];
 

--- a/playground/src/scenarios.ts
+++ b/playground/src/scenarios.ts
@@ -78,22 +78,14 @@ export const SCENARIOS: readonly TScenario[] = [
     },
   },
   {
-    label: "Localhost URL",
-    description: "Points to a locally running Fireguard instance. Useful when self-hosting.",
-    preset: {
-      url: "http://localhost:3000",
-      name: "Test App",
-    },
-  },
-  {
     label: "Custom theme",
     description: "Passes custom theme colors to the Fireguard UI alongside a logo URL.",
     preset: {
       name: "Branded App",
       logo: "../assets/logo.svg",
-      themeText: "#ffffff",
+      themeText: "#79531a",
       themePrimary: "#ee16cc",
-      themeSecondary: "#ff12ee",
+      themeSecondary: "#12ff32",
     },
   },
   {

--- a/src/enums/error-type.enum.ts
+++ b/src/enums/error-type.enum.ts
@@ -39,4 +39,11 @@ export enum ErrorType {
    * {@link InvalidFirebaseConfigError}
    */
   InvalidFirebaseConfig = 5,
+
+  /**
+   * Invalid dimension error.
+   *
+   * {@link InvalidDimError}
+   */
+  InvalidDim = 6,
 }

--- a/src/enums/event.enum.ts
+++ b/src/enums/event.enum.ts
@@ -24,4 +24,14 @@ export enum EventType {
    * Indicates a failed authentication event.
    */
   AuthFailed,
+
+  /*
+   * Requests a retry of the authentication flow in the same popup window.
+   */
+  Retry,
+
+  /*
+   * Indicates that the authentication window was explicitly closed by the user.
+   */
+  Closed,
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,6 +1,7 @@
 export * from "./base.error";
 export * from "./invalid-app-name.error";
 export * from "./invalid-app.error";
+export * from "./invalid-dim.error";
 export * from "./invalid-firebase-config.error";
 export * from "./invalid-provider.error";
 export * from "./invalid-url.error";

--- a/src/errors/invalid-dim.error.ts
+++ b/src/errors/invalid-dim.error.ts
@@ -1,0 +1,20 @@
+import { ErrorType } from "..";
+
+import { BaseError } from "./base.error";
+
+
+
+/**
+ * Custom error class representing an error that occurs when invalid dimensions are provided.
+ * This error is thrown when non-numeric or otherwise invalid width or height values are given.
+ *
+ * @category Errors
+ */
+export class InvalidDimError extends BaseError {
+  /**
+   * Creates a new instance of the InvalidDimError class with a default error message.
+   */
+  constructor() {
+    super(ErrorType.InvalidDim, "Invalid dimensions, width and height must be valid numbers");
+  }
+}

--- a/src/helpers/config.helper.ts
+++ b/src/helpers/config.helper.ts
@@ -12,6 +12,7 @@ import {
   FireguardOptionsSchema,
   FiremittOptionsSchema,
   InvalidAppNameError,
+  InvalidDimError,
   InvalidFirebaseConfigError,
   InvalidURLError,
 } from "..";
@@ -39,6 +40,10 @@ export class ConfigHelper {
   private static getDim(width: TUnsafe<number>, height: TUnsafe<number>): TDim {
     const w = Number.parseFloat((width ?? 450).toString());
     const h = Number.parseFloat((height ?? 260).toString());
+
+    if (Number.isNaN(w) || Number.isNaN(h)) {
+      throw new InvalidDimError();
+    }
 
     return { width: w, height: h };
   }

--- a/src/helpers/firemitt.helper.ts
+++ b/src/helpers/firemitt.helper.ts
@@ -5,6 +5,13 @@ import { EventType } from "..";
 
 
 /**
+ * @description
+ * Interval in milliseconds for polling whether the Fireguard popup was closed by the browser.
+ * Used only as a fallback when no Closed event is received (e.g. user clicks the native window X).
+ */
+const CLOSED_POLL_INTERVAL = 500;
+
+/**
  * Helper class for handling authentication processes using Firemitt.
  *
  * @category Helpers
@@ -35,27 +42,41 @@ export class FiremittHelper {
       }
 
       let settled = false;
+      let closedPoller: ReturnType<typeof setInterval>;
+
+      const settle = (fn: () => void) => {
+        if (!settled) {
+          settled = true;
+          clearInterval(closedPoller);
+          fn();
+        }
+      };
+
+      closedPoller = setInterval(() => {
+        if (win.closed) {
+          settle(() => reject(new Error("The authentication window was closed.")));
+        }
+      }, CLOSED_POLL_INTERVAL);
 
       const handleLoaded = () => {
         EventHelper
           .send(EventType.Config, config.fireguard)
           .on<{ token: string }>(EventType.AuthSucceded, (data) => {
-            if (!settled) {
-              settled = true;
-              resolve(data!.token);
-            }
+            settle(() => resolve(data!.token));
           })
           .on<{ error: string }>(EventType.AuthFailed, (data) => {
-            if (!settled) {
-              settled = true;
-              reject(data!.error);
-            }
+            settle(() => reject(data!.error));
+          })
+          .on(EventType.Closed, () => {
+            settle(() => reject(new Error("The authentication window was closed.")));
           });
 
         EventHelper.on(EventType.Loaded, handleLoaded);
       };
 
-      EventHelper.on(EventType.Loaded, handleLoaded);
+      EventHelper
+        .on(EventType.Loaded, handleLoaded)
+        .on(EventType.Retry, () => {});
     });
   }
 }

--- a/src/helpers/firemitt.helper.ts
+++ b/src/helpers/firemitt.helper.ts
@@ -30,13 +30,32 @@ export class FiremittHelper {
     const win = window.open(config.url, "_blank", flags) as Window;
 
     return new Promise((resolve, reject) => {
-      if (EventHelper.init(win)) {
-        EventHelper.on(EventType.Loaded, () => {
-          EventHelper.send(EventType.Config, config.fireguard)
-            .on<{ token: string }>(EventType.AuthSucceded, data => resolve(data!.token))
-            .on<{ error: string }>(EventType.AuthFailed, data => reject(data!.error));
-        });
+      if (!EventHelper.init(win)) {
+        return;
       }
+
+      let settled = false;
+
+      const handleLoaded = () => {
+        EventHelper
+          .send(EventType.Config, config.fireguard)
+          .on<{ token: string }>(EventType.AuthSucceded, (data) => {
+            if (!settled) {
+              settled = true;
+              resolve(data!.token);
+            }
+          })
+          .on<{ error: string }>(EventType.AuthFailed, (data) => {
+            if (!settled) {
+              settled = true;
+              reject(data!.error);
+            }
+          });
+
+        EventHelper.on(EventType.Loaded, handleLoaded);
+      };
+
+      EventHelper.on(EventType.Loaded, handleLoaded);
     });
   }
 }

--- a/test/config-branches.test.ts
+++ b/test/config-branches.test.ts
@@ -1,4 +1,4 @@
-import { ConfigHelper, InvalidFirebaseConfigError, InvalidURLError } from "../src/index.ts";
+import { ConfigHelper, InvalidDimError, InvalidFirebaseConfigError, InvalidURLError } from "../src/index.ts";
 import { VALID_FIREBASE } from "./fixtures.ts";
 
 
@@ -69,5 +69,35 @@ describe("tests ConfigHelper branch coverage", () => {
         config: { name: "App" },
       }),
     ).toThrow(InvalidFirebaseConfigError);
+  });
+
+  it("should throw InvalidDimError when width is NaN", () => {
+    expect(() =>
+      ConfigHelper.init({
+        url: "https://fireguard-instance.com",
+        dim: { width: Number.NaN },
+        config: { name: "App", firebase: VALID_FIREBASE },
+      }),
+    ).toThrow(InvalidDimError);
+  });
+
+  it("should throw InvalidDimError when height is NaN", () => {
+    expect(() =>
+      ConfigHelper.init({
+        url: "https://fireguard-instance.com",
+        dim: { height: Number.NaN },
+        config: { name: "App", firebase: VALID_FIREBASE },
+      }),
+    ).toThrow(InvalidDimError);
+  });
+
+  it("should use provided dim values when valid", () => {
+    const config = ConfigHelper.init({
+      url: "https://fireguard-instance.com",
+      dim: { width: 800, height: 600 },
+      config: { name: "App", firebase: VALID_FIREBASE },
+    });
+
+    expect(config.dim).toEqual({ width: 800, height: 600 });
   });
 });

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -3,6 +3,7 @@ import {
   ErrorType,
   InvalidAppError,
   InvalidAppNameError,
+  InvalidDimError,
   InvalidFirebaseConfigError,
   InvalidProviderError,
   InvalidURLError,
@@ -118,6 +119,30 @@ describe("tests InvalidProviderError", () => {
   it("toObject should return serialized error", () => {
     expect(error.toObject()).toEqual({
       type: ErrorType.InvalidProvider,
+      name: error.name,
+      message: error.message,
+    });
+  });
+});
+
+describe("tests InvalidDimError", () => {
+  const error = new InvalidDimError();
+
+  it("should have the correct name", () => {
+    expect(error.name).toBe("InvalidDimError");
+  });
+
+  it("should have the correct type", () => {
+    expect(error.type).toBe(ErrorType.InvalidDim);
+  });
+
+  it("toString should return formatted message", () => {
+    expect(error.toString()).toBe(`[${error.name}] ${error.message}.`);
+  });
+
+  it("toObject should return serialized error", () => {
+    expect(error.toObject()).toEqual({
+      type: ErrorType.InvalidDim,
       name: error.name,
       message: error.message,
     });

--- a/test/firemitt-helper.test.ts
+++ b/test/firemitt-helper.test.ts
@@ -76,5 +76,55 @@ describe("tests FiremittHelper", () => {
 
       expect(globalThis.window.addEventListener).not.toHaveBeenCalled();
     });
+
+    it("should ignore AuthSucceded after already settled via AuthFailed", async () => {
+      const authPromise = FiremittHelper.auth(BASE_OPTIONS);
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const failMsg = Base64helper.encode({ type: EventType.AuthFailed, payload: { error: "first_error" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: failMsg } as MessageEvent));
+
+      const successMsg = Base64helper.encode({ type: EventType.AuthSucceded, payload: { token: "late-token" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
+
+      await expect(authPromise).rejects.toBe("first_error");
+    });
+
+    it("should ignore AuthFailed after already settled via AuthSucceded", async () => {
+      const authPromise = FiremittHelper.auth(BASE_OPTIONS);
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const successMsg = Base64helper.encode({ type: EventType.AuthSucceded, payload: { token: "auth-token-123" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
+
+      const failMsg = Base64helper.encode({ type: EventType.AuthFailed, payload: { error: "late_error" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: failMsg } as MessageEvent));
+
+      await expect(authPromise).resolves.toBe("auth-token-123");
+    });
+
+    it("should resolve with token on successful authentication after retry", async () => {
+      const authPromise = FiremittHelper.auth(BASE_OPTIONS);
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const failMsg = Base64helper.encode({ type: EventType.AuthFailed, payload: { error: "auth_error" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: failMsg } as MessageEvent));
+
+      await expect(authPromise).rejects.toBe("auth_error");
+    });
   });
 });

--- a/test/firemitt-helper.test.ts
+++ b/test/firemitt-helper.test.ts
@@ -14,11 +14,11 @@ const BASE_OPTIONS = {
 
 describe("tests FiremittHelper", () => {
   let messageListeners: Array<(e: MessageEvent) => void>;
-  let mockWin: { postMessage: ReturnType<typeof vi.fn> };
+  let mockWin: { postMessage: ReturnType<typeof vi.fn>; closed: boolean };
 
   beforeEach(() => {
     messageListeners = [];
-    mockWin = { postMessage: vi.fn() };
+    mockWin = { postMessage: vi.fn(), closed: false };
 
     globalThis.window = {
       open: vi.fn(() => mockWin),
@@ -27,6 +27,8 @@ describe("tests FiremittHelper", () => {
         messageListeners.push(handler);
       }),
       removeEventListener: vi.fn(),
+      setInterval: vi.fn(() => 1),
+      clearInterval: vi.fn(),
     } as unknown as Window & typeof globalThis;
   });
 
@@ -125,6 +127,94 @@ describe("tests FiremittHelper", () => {
       messageListeners.forEach(h => h({ isTrusted: true, data: failMsg } as MessageEvent));
 
       await expect(authPromise).rejects.toBe("auth_error");
+    });
+
+    it("should reject when the authentication window is closed by the user", async () => {
+      vi.useFakeTimers();
+
+      const authPromise = FiremittHelper.auth(BASE_OPTIONS);
+
+      mockWin.closed = true;
+      vi.advanceTimersByTime(600);
+
+      await expect(authPromise).rejects.toThrow("The authentication window was closed.");
+
+      vi.useRealTimers();
+    });
+
+    it("should ignore the closed-window poller after the promise is already settled", async () => {
+      vi.useFakeTimers();
+
+      const authPromise = FiremittHelper.auth(BASE_OPTIONS);
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const successMsg = Base64helper.encode({ type: EventType.AuthSucceded, payload: { token: "auth-token-123" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
+
+      await expect(authPromise).resolves.toBe("auth-token-123");
+
+      mockWin.closed = true;
+      vi.advanceTimersByTime(600);
+
+      vi.useRealTimers();
+    });
+
+    it("should not reject when the poller fires while the window is still open", async () => {
+      vi.useFakeTimers();
+
+      const authPromise = FiremittHelper.auth(BASE_OPTIONS);
+
+      vi.advanceTimersByTime(600);
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const successMsg = Base64helper.encode({ type: EventType.AuthSucceded, payload: { token: "still-open-token" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
+
+      await expect(authPromise).resolves.toBe("still-open-token");
+
+      vi.useRealTimers();
+    });
+
+    it("should reject immediately when Closed event is received from Fireguard", async () => {
+      const authPromise = FiremittHelper.auth(BASE_OPTIONS);
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const closedMsg = Base64helper.encode({ type: EventType.Closed, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: closedMsg } as MessageEvent));
+
+      await expect(authPromise).rejects.toThrow("The authentication window was closed.");
+    });
+
+    it("should not settle on Retry and resolve after next Loaded flow", async () => {
+      const authPromise = FiremittHelper.auth(BASE_OPTIONS);
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const retryMsg = Base64helper.encode({ type: EventType.Retry, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: retryMsg } as MessageEvent));
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const successMsg = Base64helper.encode({ type: EventType.AuthSucceded, payload: { token: "retry-token" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
+
+      await expect(authPromise).resolves.toBe("retry-token");
     });
   });
 });


### PR DESCRIPTION
### Summary

Fixes two popup-related issues and adds dimension validation.

### Changes

#### `Retry` and `Closed` event types

Added two new `EventType` members:

- `Retry` — sent by Fireguard when the user clicks Retry on the failure page. Firemitt treats this as a no-op and stays listening; the popup reloads itself and sends `Loaded` again, restarting the auth flow in the same window without calling `window.open` a second time (which would be blocked by the browser popup blocker).
- `Closed` — sent by Fireguard when the user explicitly clicks Close. Firemitt immediately rejects the auth promise on receipt.

#### Popup close detection (`FiremittHelper.auth`)

Previously, if the user closed the Fireguard popup window directly (native browser X button), the `auth` promise hung indefinitely. The fix introduces:

- A `settle` helper that guarantees single-resolution of the promise regardless of which path triggers it.
- A `setInterval` poller checking `win.closed` every 500ms as a **fallback** — used only when no `Closed` event is received (i.e. native browser close). The interval is cleared immediately when the promise settles via any path.
- A `Closed` event handler that settles the promise immediately, making the poller irrelevant for app-driven closes.
- A `Retry` event handler (intentional no-op) so that the persistent `Loaded` listener correctly re-sends config after the popup reloads.

#### `InvalidDimError` for non-numeric dimensions

- Added `ErrorType.InvalidDim = 6`.
- Added `InvalidDimError` class extending `BaseError`.
- `ConfigHelper.getDim` now throws `InvalidDimError` when either parsed dimension is `NaN`.
- Updated `FiremittOptionsSchema` dim fields from `z.number().finite()` (deprecated in Zod 4) to `z.number()` — Zod 4's base `z.number()` already rejects `NaN` and `Infinity`.

### Tests

- 66 tests passing, 100% statement/branch/function/line coverage.
- New test suites: `InvalidDimError`, `Closed` event rejection, `Retry` no-op + next-`Loaded` resolution, `win.closed` polling fallback, NaN dim validation branches.
