### PR TITLE
Multiple Providers

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -394,6 +394,19 @@
                 <label for="logo">Logo URL</label>
                 <input type="url" id="logo" placeholder="https://example.com/logo.png" />
               </div>
+              <div class="field">
+                <label for="provider">Auth provider</label>
+                <input type="text" id="provider" placeholder="google" list="provider-list" />
+                <datalist id="provider-list">
+                  <option value="google"></option>
+                  <option value="github"></option>
+                  <option value="facebook"></option>
+                  <option value="twitter"></option>
+                  <option value="microsoft"></option>
+                  <option value="apple"></option>
+                  <option value="yahoo"></option>
+                </datalist>
+              </div>
               <div class="color-row">
                 <div>
                   <label for="themeText">Text color</label>

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -4,7 +4,7 @@ import { SCENARIOS } from "./scenarios";
 
 
 
-const DEFAULT_FIREGUARD_URL = import.meta.env.VITE_FIREGUARD_URL || "https://ouss.es/fireguard";
+const DEFAULT_FIREGUARD_URL = import.meta.env.VITE_FIREGUARD_URL || "http://localhost:5173";
 
 function getField(id: string): HTMLInputElement {
   return document.getElementById(id) as HTMLInputElement;
@@ -31,6 +31,12 @@ function readForm(): TFormValues {
     posX: getField("posX").value.trim(),
     posY: getField("posY").value.trim(),
   };
+}
+
+function syncUrlChips(url: string): void {
+  document.querySelectorAll<HTMLButtonElement>(".url-preset-btn").forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.url === url);
+  });
 }
 
 function applyPreset(preset: Partial<TFormValues>): void {
@@ -64,6 +70,8 @@ function applyPreset(preset: Partial<TFormValues>): void {
       el.value = value;
     }
   }
+
+  syncUrlChips(resolved.url);
 }
 
 function setResult(state: "idle" | "pending" | "success" | "error", message: string): void {
@@ -110,7 +118,7 @@ async function runAuth(): Promise<void> {
     config: {
       name: values.name,
       ...(values.logo ? { logo: values.logo } : {}),
-      provider: values.provider || "google",
+      provider: values.provider.toLowerCase() || "google",
       ...(values.themeText && values.themePrimary && values.themeSecondary
         ? {
             theme: {
@@ -171,10 +179,10 @@ function setActiveScenario(active: HTMLButtonElement): void {
 
 function buildUrlPresets(): void {
   const presets = [
-    { label: "Default", value: DEFAULT_FIREGUARD_URL },
     { label: "localhost:5173", value: "http://localhost:5173" },
     { label: "localhost:5174", value: "http://localhost:5174" },
-    { label: "https://ouss.es/fireguard", value: "http://https://ouss.es/fireguard" },
+    { label: "localhost:8080", value: "http://localhost:8080" },
+    { label: "Hosted", value: "https://ouss.es/fireguard" },
   ];
 
   const bar = document.getElementById("url-presets") as HTMLElement;
@@ -184,15 +192,11 @@ function buildUrlPresets(): void {
 
     btn.className = "url-preset-btn";
     btn.textContent = preset.label;
+    btn.dataset.url = preset.value;
     btn.addEventListener("click", () => {
       getField("url").value = preset.value;
-      document.querySelectorAll(".url-preset-btn").forEach(b => b.classList.remove("active"));
-      btn.classList.add("active");
+      syncUrlChips(preset.value);
     });
-
-    if (preset.value === DEFAULT_FIREGUARD_URL) {
-      btn.classList.add("active");
-    }
 
     bar.appendChild(btn);
   }
@@ -222,6 +226,11 @@ function init(): void {
   buildUrlPresets();
   buildScenarios();
   seedFromEnv();
+  syncUrlChips(DEFAULT_FIREGUARD_URL);
+
+  getField("url").addEventListener("input", () => {
+    syncUrlChips(getField("url").value.trim());
+  });
 
   document.getElementById("run-btn")!.addEventListener("click", () => {
     void runAuth();

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -15,6 +15,7 @@ function readForm(): TFormValues {
     url: getField("url").value.trim(),
     name: getField("name").value.trim(),
     logo: getField("logo").value.trim(),
+    provider: getField("provider").value.trim(),
     apiKey: getField("apiKey").value.trim(),
     appId: getField("appId").value.trim(),
     projectId: getField("projectId").value.trim(),
@@ -37,6 +38,7 @@ function applyPreset(preset: Partial<TFormValues>): void {
     url: DEFAULT_FIREGUARD_URL,
     name: "",
     logo: "",
+    provider: "",
     apiKey: import.meta.env.VITE_FIREBASE_API_KEY ?? "",
     appId: import.meta.env.VITE_FIREBASE_APP_ID ?? "",
     projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID ?? "",
@@ -108,6 +110,7 @@ async function runAuth(): Promise<void> {
     config: {
       name: values.name,
       ...(values.logo ? { logo: values.logo } : {}),
+      provider: values.provider || "google",
       ...(values.themeText && values.themePrimary && values.themeSecondary
         ? {
             theme: {
@@ -168,10 +171,10 @@ function setActiveScenario(active: HTMLButtonElement): void {
 
 function buildUrlPresets(): void {
   const presets = [
-    { label: "Hosted", value: DEFAULT_FIREGUARD_URL },
+    { label: "Default", value: DEFAULT_FIREGUARD_URL },
     { label: "localhost:5173", value: "http://localhost:5173" },
     { label: "localhost:5174", value: "http://localhost:5174" },
-    { label: "localhost:8080", value: "http://localhost:8080" },
+    { label: "https://ouss.es/fireguard", value: "http://https://ouss.es/fireguard" },
   ];
 
   const bar = document.getElementById("url-presets") as HTMLElement;

--- a/playground/src/scenarios.ts
+++ b/playground/src/scenarios.ts
@@ -2,6 +2,7 @@ export type TFormValues = {
   readonly url: string;
   readonly name: string;
   readonly logo: string;
+  readonly provider: string;
   readonly apiKey: string;
   readonly appId: string;
   readonly projectId: string;
@@ -75,6 +76,14 @@ export const SCENARIOS: readonly TScenario[] = [
       measurementId: "",
       storageBucket: "",
       messagingSenderId: "",
+    },
+  },
+  {
+    label: "GitHub provider",
+    description: "Uses GitHub as the auth provider instead of the default Google.",
+    preset: {
+      name: "Test App",
+      provider: "github",
     },
   },
   {

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -1,2 +1,3 @@
 export * from "./error-type.enum";
 export * from "./event.enum";
+export * from "./provider.enum";

--- a/src/enums/provider.enum.ts
+++ b/src/enums/provider.enum.ts
@@ -1,0 +1,16 @@
+/**
+ * Supported Firebase authentication providers.
+ *
+ * @category Enums
+ */
+export const EProvider = {
+  GOOGLE: "google",
+  GITHUB: "github",
+  FACEBOOK: "facebook",
+  TWITTER: "twitter",
+  MICROSOFT: "microsoft",
+  APPLE: "apple",
+  YAHOO: "yahoo",
+} as const;
+
+export type TProvider = (typeof EProvider)[keyof typeof EProvider] | string;

--- a/src/helpers/config.helper.ts
+++ b/src/helpers/config.helper.ts
@@ -108,6 +108,8 @@ export class ConfigHelper {
       messagingSenderId: "",
     };
 
+    const provider = config?.provider ?? "google";
+
     const nameResult = FireguardOptionsSchema.shape.name.safeParse(name);
 
     if (!nameResult.success) {
@@ -120,7 +122,7 @@ export class ConfigHelper {
       throw new InvalidFirebaseConfigError();
     }
 
-    return { name, logo, theme, firebase };
+    return { name, logo, theme, firebase, provider };
   }
 
   /**

--- a/src/helpers/event.helper.ts
+++ b/src/helpers/event.helper.ts
@@ -17,16 +17,32 @@ import { Base64helper } from ".";
  */
 export class EventHelper {
   private static target: Window;
+  private static handlers: Set<(e: MessageEvent) => void> = new Set();
+
+  /**
+   * Removes all active message listeners registered by this helper.
+   * Called before each new session to prevent stale handlers from a previous
+   * auth call from intercepting events meant for the new popup.
+   */
+  private static cleanup(): void {
+    for (const handler of this.handlers) {
+      window.removeEventListener("message", handler);
+    }
+
+    this.handlers.clear();
+  }
 
   /**
    * Initializes the EventHelper with a target window.
    *
    * This method sets the target window where the messages will be posted to.
+   * Any listeners registered during a previous session are removed first.
    *
    * @param {Window} target - The target window to which messages will be sent.
    * @returns {boolean} Returns true if the target is successfully set, otherwise false.
    */
   static init(target: Window): boolean {
+    this.cleanup();
     this.target = target;
 
     return Boolean(this.target);
@@ -70,10 +86,12 @@ export class EventHelper {
         if (message.type === type) {
           func(message.payload as T);
           window.removeEventListener("message", handler);
+          this.handlers.delete(handler);
         }
       }
     };
 
+    this.handlers.add(handler);
     window.addEventListener("message", handler);
 
     return this;

--- a/src/schemas/fireguard-options.schema.ts
+++ b/src/schemas/fireguard-options.schema.ts
@@ -14,6 +14,7 @@ export const FireguardOptionsSchema = z.object({
   name: z.string().min(1),
   firebase: FirebaseConfigSchema,
   logo: z.string().optional(),
+  provider: z.string().min(1).optional(),
   theme: z
     .object({
       text: z.string(),

--- a/src/types/fireguard-config.type.ts
+++ b/src/types/fireguard-config.type.ts
@@ -33,4 +33,10 @@ export type TFireguardConfig = {
    * The Firebase configuration settings for the Fireguard.
    */
   firebase: TFirebaseConfig;
+
+  /**
+   * The authentication provider to use. Defaults to "google".
+   * Use values from `EProvider` or a custom "oidc.<id>" / "saml.<id>" string.
+   */
+  provider: string;
 };

--- a/src/types/token.type.ts
+++ b/src/types/token.type.ts
@@ -14,8 +14,13 @@ export type TToken = {
   _tokenResponse: {
 
     /**
-     * The OAuth ID token.
+     * The OAuth ID token. Present for OIDC-based providers (Google, Apple, Microsoft).
      */
-    oauthIdToken: string;
+    oauthIdToken?: string;
+
+    /**
+     * The OAuth access token. Present for all OAuth providers.
+     */
+    oauthAccessToken?: string;
   };
 } & object;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -61,6 +61,7 @@ describe("configHelper", () => {
           logo: "",
           theme: { text: "#1a3544", primary: "#ffe536", secondary: "#1a3544" },
           firebase: VALID_FIREBASE,
+          provider: "google",
         },
       });
 


### PR DESCRIPTION
Adds a `provider` field to the Fireguard config, allowing callers to choose any Firebase-supported OAuth provider instead of being locked to Google.

### Changes

**`src/enums/provider.enum.ts`** *(new)*
Introduces `EProvider`, an enum-like `as const` object with named constants for all supported popup-capable providers: `google`, `github`, `facebook`, `twitter`, `microsoft`, `apple`, `yahoo`. Exports `TProvider` as the derived union type.

**`src/enums/index.ts`**
Exports `EProvider` and `TProvider` from the new enum file.

**`src/types/fireguard-config.type.ts`**
Adds a `provider: string` field to `TFireguardConfig`. Accepts any `EProvider` value or a custom `"oidc.<id>"` / `"saml.<id>"` string for enterprise providers.

**`src/types/token.type.ts`**
Makes both `oauthIdToken` and `oauthAccessToken` optional on `_tokenResponse`. OIDC-backed providers (Google, Apple) return `oauthIdToken`; non-OIDC providers (GitHub, Facebook, Twitter) only return `oauthAccessToken`. The auth helper now reads whichever field is present.

**`src/schemas/fireguard-options.schema.ts`**
Adds an optional `provider: z.string().min(1)` field to the Fireguard options schema.

**`src/helpers/config.helper.ts`**
`getFireguardConfig()` reads `config.provider`, defaulting to `"google"` when omitted, and includes it in the returned `TFireguardConfig`.

**`src/helpers/event.helper.ts`**
Fixes a stale event listener bug. `EventHelper` now tracks all active handlers in a private static `Set`. `init()` calls an internal `cleanup()` before registering the new target window, removing any listeners left over from a previous auth session. Without this fix, changing the form config and clicking "Run Auth" a second time would result in Fireguard receiving the old config because the stale `Loaded` handler fired first.

**`test/config.test.ts`**
Updates the config fixture to include `provider: "google"` to satisfy the updated `TFireguardConfig` shape.

**`playground/src/scenarios.ts`**
Adds `provider` to `TFormValues`. Adds a "GitHub provider" scenario to demonstrate switching from the default Google provider.

**`playground/src/main.ts`**
- Reads the `provider` field from the form on every Run Auth click.
- Normalizes provider input with `.toLowerCase()`.
- Always sends an explicit `provider` value (defaults to `"google"` when blank).
- Fixes the URL chip active state: introduces `syncUrlChips(url)` which uses `data-url` attributes for accurate matching. Chips now sync on page load, on chip click, on scenario selection (which resets the URL field), and on manual URL input.
- Fixes a malformed hosted URL preset that had `"http://https://..."` as its value.
- Changes the default fallback URL from `https://ouss.es/fireguard` to `http://localhost:5173` so the playground targets a local Fireguard dev server by default.

**`playground/index.html`**
Adds an "Auth provider" text input with a `<datalist>` offering all seven known provider values as autocomplete suggestions. Custom `oidc.*` / `saml.*` strings can still be typed freely.

### Usage

```ts
FiremittHelper.auth({
  url: "http://localhost:5173",
  config: {
    name: "My App",
    firebase: { /* ... */ },
    provider: "github", // or "facebook", "twitter", "microsoft", "apple", "yahoo"
                        // or "oidc.my-id" / "saml.my-id" for enterprise
  },
});
```

Omitting `provider` defaults to `"google"`, so existing integrations are unaffected.

### Testing

- All 66 existing tests pass.
- Build produces no type errors.
- Lint reports no issues.
