### PR TITLE
feat: iframe embedding support

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -358,7 +358,6 @@
     <header>
       <img src="https://raw.githubusercontent.com/eoussama/firemitt/refs/heads/main/assets/firemitt.svg" alt="Firemitt Logo" />
       <h1>Firemitt Playground</h1>
-      <span>Edge-case testing playground</span>
     </header>
 
     <div class="layout">

--- a/playground/index.html
+++ b/playground/index.html
@@ -496,6 +496,19 @@
         </div>
 
         <div class="section">
+          <div class="section-title">Mode</div>
+          <div class="field">
+            <label for="mode">Auth mode</label>
+            <select id="mode" style="width:100%;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);font-size:13px;padding:7px 10px;outline:none;font-family:var(--font);">
+              <option value="">popup (default)</option>
+              <option value="iframe">iframe (embedded)</option>
+              <option value="iframe-dialog">iframe (dialog)</option>
+              <option value="iframe-element">iframe (existing element)</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="section">
           <button id="run-btn">Run Auth</button>
         </div>
 
@@ -503,9 +516,40 @@
           <div class="result-label">Result</div>
           <div class="result-badge"></div>
           <div id="result-text">No result yet. Configure a scenario and click Run Auth.</div>
+          <div id="iframe-container" style="margin-top:16px;border-radius:var(--radius);overflow:hidden;"></div>
+          <iframe
+            id="fireguard-iframe"
+            style="display:none;margin-top:16px;border:1px solid var(--border);border-radius:var(--radius);width:450px;height:260px;"
+          ></iframe>
         </div>
       </div>
     </div>
+
+    <dialog id="iframe-dialog" style="
+      padding: 0;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      max-width: 90vw;
+      max-height: 90vh;
+      overflow: hidden;
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      margin: 0;
+    ">
+      <div style="display:flex;align-items:center;justify-content:space-between;padding:10px 14px;border-bottom:1px solid var(--border);background:var(--surface-2);">
+        <span style="font-size:12px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;color:var(--text-muted);">Fireguard Auth</span>
+        <button
+          onclick="document.getElementById('iframe-dialog').close()"
+          style="background:none;border:none;color:var(--text-muted);cursor:pointer;font-size:16px;line-height:1;padding:2px 6px;"
+          title="Close"
+        >&times;</button>
+      </div>
+      <div class="dialog-iframe-container" style="display:flex;align-items:center;justify-content:center;"></div>
+    </dialog>
 
     <script type="module" src="src/main.ts"></script>
   </body>

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -30,6 +30,7 @@ function readForm(): TFormValues {
     dimHeight: getField("dimHeight").value.trim(),
     posX: getField("posX").value.trim(),
     posY: getField("posY").value.trim(),
+    mode: (document.getElementById("mode") as HTMLSelectElement)?.value?.trim() ?? "",
   };
 }
 
@@ -59,6 +60,7 @@ function applyPreset(preset: Partial<TFormValues>): void {
     dimHeight: "",
     posX: "",
     posY: "",
+    mode: "",
   };
 
   const resolved = { ...defaults, ...preset };
@@ -96,9 +98,44 @@ async function runAuth(): Promise<void> {
   };
 
   const allFirebaseEmpty = Object.values(firebase).every(v => v === "");
+  const isIframe = values.mode === "iframe";
+  const isIframeDialog = values.mode === "iframe-dialog";
+  const isIframeElement = values.mode === "iframe-element";
+
+  const iframeContainer = isIframe
+    ? (document.getElementById("iframe-container") as HTMLElement)
+    : undefined;
+
+  let dialogContainer: HTMLElement | undefined;
+
+  if (isIframeDialog) {
+    const dialog = document.getElementById("iframe-dialog") as HTMLDialogElement;
+
+    dialogContainer = dialog.querySelector<HTMLElement>(".dialog-iframe-container") ?? undefined;
+    dialog.showModal();
+  }
+
+  let existingIframe: HTMLIFrameElement | undefined;
+
+  if (isIframeElement) {
+    existingIframe = document.getElementById("fireguard-iframe") as HTMLIFrameElement;
+    existingIframe.style.display = "block";
+  }
+  else {
+    const el = document.getElementById("fireguard-iframe") as HTMLIFrameElement;
+
+    el.style.display = "none";
+  }
 
   const options = {
     url: values.url,
+    ...(isIframe
+      ? { mode: "iframe" as const, iframe: { container: iframeContainer! } }
+      : isIframeDialog
+        ? { mode: "iframe" as const, iframe: { container: dialogContainer! } }
+        : isIframeElement
+          ? { mode: "iframe" as const, iframe: { element: existingIframe! } }
+          : {}),
     ...(values.dimWidth || values.dimHeight
       ? {
           dim: {
@@ -132,14 +169,26 @@ async function runAuth(): Promise<void> {
     },
   };
 
-  setResult("pending", "Waiting for authentication...");
+  const pendingMsg = (isIframe || isIframeDialog || isIframeElement)
+    ? "Waiting for authentication in iframe..."
+    : "Waiting for authentication...";
+
+  setResult("pending", pendingMsg);
 
   try {
     const token = await FiremittHelper.auth(options);
 
+    if (isIframeDialog) {
+      (document.getElementById("iframe-dialog") as HTMLDialogElement).close();
+    }
+
     setResult("success", `Token: ${token}`);
   }
   catch (err) {
+    if (isIframeDialog) {
+      (document.getElementById("iframe-dialog") as HTMLDialogElement).close();
+    }
+
     const message = err instanceof Error ? err.message : String(err);
 
     setResult("error", message);

--- a/playground/src/scenarios.ts
+++ b/playground/src/scenarios.ts
@@ -17,6 +17,7 @@ export type TFormValues = {
   readonly dimHeight: string;
   readonly posX: string;
   readonly posY: string;
+  readonly mode: string;
 };
 
 export type TScenario = {
@@ -115,6 +116,30 @@ export const SCENARIOS: readonly TScenario[] = [
       name: "Test App",
       dimWidth: "wide",
       dimHeight: "tall",
+    },
+  },
+  {
+    label: "Iframe embed (auto-create)",
+    description: "Opens Fireguard embedded in an iframe created inside the result panel. Uses mode: \"iframe\" with a container.",
+    preset: {
+      name: "Test App",
+      mode: "iframe",
+    },
+  },
+  {
+    label: "Iframe embed (dialog)",
+    description: "Opens Fireguard embedded in an iframe inside a modal <dialog>. The dialog closes automatically when auth resolves or rejects.",
+    preset: {
+      name: "Test App",
+      mode: "iframe-dialog",
+    },
+  },
+  {
+    label: "Iframe embed (existing element)",
+    description: "Reuses a persistent <iframe> element already in the DOM. Fireguard is loaded into it without Firemitt managing its lifecycle.",
+    preset: {
+      name: "Test App",
+      mode: "iframe-element",
     },
   },
 ];

--- a/src/enums/error-type.enum.ts
+++ b/src/enums/error-type.enum.ts
@@ -46,4 +46,11 @@ export enum ErrorType {
    * {@link InvalidDimError}
    */
   InvalidDim = 6,
+
+  /**
+   * Invalid iframe error.
+   *
+   * {@link InvalidIframeError}
+   */
+  InvalidIframe = 7,
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -3,5 +3,6 @@ export * from "./invalid-app-name.error";
 export * from "./invalid-app.error";
 export * from "./invalid-dim.error";
 export * from "./invalid-firebase-config.error";
+export * from "./invalid-iframe.error";
 export * from "./invalid-provider.error";
 export * from "./invalid-url.error";

--- a/src/errors/invalid-iframe.error.ts
+++ b/src/errors/invalid-iframe.error.ts
@@ -1,0 +1,20 @@
+import { ErrorType } from "..";
+
+import { BaseError } from "./base.error";
+
+
+
+/**
+ * Custom error class representing an error that occurs when iframe mode is
+ * selected but neither an iframe element nor a container element is provided.
+ *
+ * @category Errors
+ */
+export class InvalidIframeError extends BaseError {
+  /**
+   * Creates a new instance of the InvalidIframeError class with a default error message.
+   */
+  constructor() {
+    super(ErrorType.InvalidIframe, "iframe mode requires either an iframe element or a container element");
+  }
+}

--- a/src/helpers/event.helper.ts
+++ b/src/helpers/event.helper.ts
@@ -17,6 +17,7 @@ import { Base64helper } from ".";
  */
 export class EventHelper {
   private static target: Window;
+  private static hostWindow: Window = globalThis.window;
   private static handlers: Set<(e: MessageEvent) => void> = new Set();
 
   /**
@@ -26,7 +27,7 @@ export class EventHelper {
    */
   private static cleanup(): void {
     for (const handler of this.handlers) {
-      window.removeEventListener("message", handler);
+      this.hostWindow.removeEventListener("message", handler);
     }
 
     this.handlers.clear();
@@ -37,11 +38,13 @@ export class EventHelper {
    *
    * This method sets the target window where the messages will be posted to.
    * Any listeners registered during a previous session are removed first.
+   * The calling page's window is captured as the host window for message listeners.
    *
    * @param {Window} target - The target window to which messages will be sent.
    * @returns {boolean} Returns true if the target is successfully set, otherwise false.
    */
   static init(target: Window): boolean {
+    this.hostWindow = window;
     this.cleanup();
     this.target = target;
 
@@ -81,18 +84,25 @@ export class EventHelper {
   static on<T = unknown>(type: EventType, func: (data?: T) => void): typeof EventHelper {
     const handler = (e: MessageEvent) => {
       if (e.isTrusted) {
-        const message = Base64helper.decode(e.data);
+        let message: ReturnType<typeof Base64helper.decode>;
+
+        try {
+          message = Base64helper.decode(e.data);
+        }
+        catch {
+          return;
+        }
 
         if (message.type === type) {
           func(message.payload as T);
-          window.removeEventListener("message", handler);
+          this.hostWindow.removeEventListener("message", handler);
           this.handlers.delete(handler);
         }
       }
     };
 
     this.handlers.add(handler);
-    window.addEventListener("message", handler);
+    this.hostWindow.addEventListener("message", handler);
 
     return this;
   }

--- a/src/helpers/firemitt.helper.ts
+++ b/src/helpers/firemitt.helper.ts
@@ -23,6 +23,12 @@ const CLOSED_POLL_INTERVAL = 500;
  */
 export class FiremittHelper {
   /**
+   * Cancels the currently active iframe session, if any.
+   * Removes the owned iframe from the DOM and rejects its promise.
+   */
+  private static cancelActiveIframe: (() => void) | null = null;
+
+  /**
    * Runs the shared event-driven auth flow against an already-initialized `EventHelper` target.
    * Resolves with the token on success, rejects on failure or close.
    * The `cleanup` callback is invoked once the promise settles (regardless of outcome).
@@ -130,6 +136,7 @@ export class FiremittHelper {
   /**
    * Initiates authentication by embedding Fireguard inside an iframe.
    * Uses a caller-provided iframe element, or creates one inside the provided container.
+   * If a previous iframe session is still active, it is cancelled before starting the new one.
    *
    * @param options - The options required to configure and initiate the Firemitt authentication process.
    * @returns A promise that resolves with the authentication token on success, or rejects with an error on failure.
@@ -141,6 +148,9 @@ export class FiremittHelper {
     if (!iframeOpts?.element && !iframeOpts?.container) {
       throw new InvalidIframeError();
     }
+
+    FiremittHelper.cancelActiveIframe?.();
+    FiremittHelper.cancelActiveIframe = null;
 
     const config = ConfigHelper.init(options);
 
@@ -156,16 +166,35 @@ export class FiremittHelper {
       iframeOpts.container!.appendChild(iframe);
     }
 
+    if (owned) {
+      iframe.style.width = `${config.dim.width}px`;
+      iframe.style.height = `${config.dim.height}px`;
+    }
+
     iframe.src = config.url;
 
     const cleanup = () => {
+      FiremittHelper.cancelActiveIframe = null;
+
       if (owned && iframe.parentNode) {
         iframe.parentNode.removeChild(iframe);
       }
     };
 
     return new Promise<string>((resolve, reject) => {
+      let cancelled = false;
+
+      FiremittHelper.cancelActiveIframe = () => {
+        cancelled = true;
+        cleanup();
+        reject(new Error("A new authentication session was started."));
+      };
+
       iframe.addEventListener("load", () => {
+        if (cancelled) {
+          return;
+        }
+
         const win = iframe.contentWindow;
 
         if (!win || !EventHelper.init(win)) {

--- a/src/helpers/firemitt.helper.ts
+++ b/src/helpers/firemitt.helper.ts
@@ -1,6 +1,6 @@
 import type { TFiremittOptions } from "../types/firemitt-options.type";
 import { ConfigHelper, EventHelper } from ".";
-import { EventType } from "..";
+import { EventType, InvalidIframeError } from "..";
 
 
 
@@ -23,26 +23,71 @@ const CLOSED_POLL_INTERVAL = 500;
  */
 export class FiremittHelper {
   /**
-   * Initiates authentication using Firemitt options.
+   * Runs the shared event-driven auth flow against an already-initialized `EventHelper` target.
+   * Resolves with the token on success, rejects on failure or close.
+   * The `cleanup` callback is invoked once the promise settles (regardless of outcome).
    *
-   * This static method opens a new window with the Firemitt URL and sets up event listeners to handle the authentication process.
-   * It listens for authentication success or failure events and resolves or rejects the promise accordingly.
-   *
-   * @param {TFiremittOptions} options - The options required to configure and initiate the Firemitt authentication process.
-   * @returns {Promise<string>} A promise that resolves with the authentication token on success, or rejects with an error on failure.
+   * @param fireguardConfig - The Fireguard config to send after the Loaded event.
+   * @param cleanup - Teardown to run after settling.
+   * @returns A promise that resolves with the authentication token or rejects with an error.
    */
-  static auth(options: TFiremittOptions): Promise<string> {
+  /* v8 ignore next */
+  private static runSession(
+    fireguardConfig: ReturnType<typeof ConfigHelper.init>["fireguard"],
+    cleanup: () => void,
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+
+      const settle = (fn: () => void) => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          fn();
+        }
+      };
+
+      const handleLoaded = () => {
+        EventHelper
+          .send(EventType.Config, fireguardConfig)
+          .on<{ token: string }>(EventType.AuthSucceded, (data) => {
+            settle(() => resolve(data!.token));
+          })
+          .on<{ error: string }>(EventType.AuthFailed, (data) => {
+            settle(() => reject(data!.error));
+          })
+          .on(EventType.Closed, () => {
+            settle(() => reject(new Error("The authentication window was closed.")));
+          });
+
+        EventHelper.on(EventType.Loaded, handleLoaded);
+      };
+
+      EventHelper
+        .on(EventType.Loaded, handleLoaded)
+        .on(EventType.Retry, () => {});
+    });
+  }
+
+  /**
+   * Initiates authentication using a popup window.
+   *
+   * @param options - The options required to configure and initiate the Firemitt authentication process.
+   * @returns A promise that resolves with the authentication token on success, or rejects with an error on failure.
+   */
+  private static authPopup(options: TFiremittOptions): Promise<string> {
     const config = ConfigHelper.init(options);
     const flags = ConfigHelper.getFlags(config);
     const win = window.open(config.url, "_blank", flags) as Window;
 
-    return new Promise((resolve, reject) => {
-      if (!EventHelper.init(win)) {
-        return;
-      }
+    if (!EventHelper.init(win)) {
+      return new Promise(() => {});
+    }
 
+    let closedPoller: ReturnType<typeof setInterval>;
+
+    const promise = new Promise<string>((resolve, reject) => {
       let settled = false;
-      let closedPoller: ReturnType<typeof setInterval>;
 
       const settle = (fn: () => void) => {
         if (!settled) {
@@ -78,5 +123,77 @@ export class FiremittHelper {
         .on(EventType.Loaded, handleLoaded)
         .on(EventType.Retry, () => {});
     });
+
+    return promise;
+  }
+
+  /**
+   * Initiates authentication by embedding Fireguard inside an iframe.
+   * Uses a caller-provided iframe element, or creates one inside the provided container.
+   *
+   * @param options - The options required to configure and initiate the Firemitt authentication process.
+   * @returns A promise that resolves with the authentication token on success, or rejects with an error on failure.
+   * @throws {InvalidIframeError} If neither an iframe element nor a container is provided.
+   */
+  private static authIframe(options: TFiremittOptions): Promise<string> {
+    const { iframe: iframeOpts } = options;
+
+    if (!iframeOpts?.element && !iframeOpts?.container) {
+      throw new InvalidIframeError();
+    }
+
+    const config = ConfigHelper.init(options);
+
+    let iframe: HTMLIFrameElement;
+    let owned = false;
+
+    if (iframeOpts.element) {
+      iframe = iframeOpts.element;
+    }
+    else {
+      iframe = document.createElement("iframe");
+      owned = true;
+      iframeOpts.container!.appendChild(iframe);
+    }
+
+    iframe.src = config.url;
+
+    const cleanup = () => {
+      if (owned && iframe.parentNode) {
+        iframe.parentNode.removeChild(iframe);
+      }
+    };
+
+    return new Promise<string>((resolve, reject) => {
+      iframe.addEventListener("load", () => {
+        const win = iframe.contentWindow;
+
+        if (!win || !EventHelper.init(win)) {
+          cleanup();
+          reject(new Error("Could not access the iframe window."));
+
+          return;
+        }
+
+        FiremittHelper.runSession(config.fireguard, cleanup).then(resolve, reject);
+      }, { once: true });
+    });
+  }
+
+  /**
+   * Initiates authentication using Firemitt options.
+   *
+   * Depending on the `mode` field in `options`, this either opens a popup window (default)
+   * or embeds Fireguard inside an iframe.
+   *
+   * @param {TFiremittOptions} options - The options required to configure and initiate the Firemitt authentication process.
+   * @returns {Promise<string>} A promise that resolves with the authentication token on success, or rejects with an error on failure.
+   */
+  static auth(options: TFiremittOptions): Promise<string> {
+    if (options.mode === "iframe") {
+      return FiremittHelper.authIframe(options);
+    }
+
+    return FiremittHelper.authPopup(options);
   }
 }

--- a/src/schemas/firemitt-options.schema.ts
+++ b/src/schemas/firemitt-options.schema.ts
@@ -37,4 +37,11 @@ export const FiremittOptionsSchema = z.object({
     })
     .optional(),
   config: FireguardOptionsSchema.partial().optional(),
+  mode: z.enum(["popup", "iframe"]).optional(),
+  iframe: z
+    .union([
+      z.object({ element: z.custom<HTMLIFrameElement>(), container: z.never().optional() }),
+      z.object({ container: z.custom<HTMLElement>(), element: z.never().optional() }),
+    ])
+    .optional(),
 });

--- a/src/types/iframe-options.type.ts
+++ b/src/types/iframe-options.type.ts
@@ -1,0 +1,20 @@
+/**
+ * Options for embedding Fireguard in an iframe.
+ * Provide either an existing `element` or a `container` where Firemitt will
+ * create and manage the iframe automatically.
+ *
+ * @category Firemitt
+ *
+ * @type {TIframeOptions}
+ */
+export type TIframeOptions
+  = | {
+    /** An existing iframe element to use for embedding. */
+    readonly element: HTMLIFrameElement;
+    readonly container?: never;
+  }
+  | {
+    /** A container element where Firemitt will create and append an iframe. */
+    readonly container: HTMLElement;
+    readonly element?: never;
+  };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export * from "./fireguard-config.type";
 export * from "./fireguard-options.type";
 export * from "./firemitt-config.type";
 export * from "./firemitt-options.type";
+export * from "./iframe-options.type";
 export * from "./message.type";
 export * from "./pos.type";
 export * from "./theme.type";

--- a/test/event-helper.test.ts
+++ b/test/event-helper.test.ts
@@ -71,6 +71,20 @@ describe("tests EventHelper", () => {
       expect(callback).not.toHaveBeenCalled();
     });
 
+    it("should silently ignore messages that are not valid base64", () => {
+      EventHelper.init(mockTarget as unknown as Window);
+
+      const callback = vi.fn();
+
+      EventHelper.on(EventType.Loaded, callback);
+
+      expect(() => {
+        messageListeners[0]({ isTrusted: true, data: "not-valid-base64!!!" } as MessageEvent);
+      }).not.toThrow();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
     it("should not invoke the callback for untrusted messages", () => {
       EventHelper.init(mockTarget as unknown as Window);
 

--- a/test/firemitt-helper.test.ts
+++ b/test/firemitt-helper.test.ts
@@ -250,6 +250,14 @@ describe("tests FiremittHelper", () => {
       });
     });
 
+    afterEach(() => {
+      const helper = FiremittHelper as unknown as { cancelActiveIframe: (() => void) | null };
+
+      if (helper.cancelActiveIframe) {
+        helper.cancelActiveIframe = null;
+      }
+    });
+
     it("should throw InvalidIframeError when neither element nor container is given", () => {
       expect(() =>
         FiremittHelper.auth({ ...BASE_OPTIONS, mode: "iframe" }),
@@ -343,6 +351,7 @@ describe("tests FiremittHelper", () => {
     it("should create an iframe inside the container and remove it on success", async () => {
       const createdIframe = {
         src: "",
+        style: { width: "", height: "" },
         contentWindow: iframeWin,
         parentNode: { removeChild: vi.fn() },
         addEventListener: vi.fn((event: string, handler: () => void) => {
@@ -366,6 +375,8 @@ describe("tests FiremittHelper", () => {
 
       expect(container.appendChild).toHaveBeenCalledWith(createdIframe);
       expect(createdIframe.src).toBe("https://fireguard-instance.com/");
+      expect(createdIframe.style.width).toBe("450px");
+      expect(createdIframe.style.height).toBe("260px");
 
       loadHandler!();
 
@@ -382,9 +393,69 @@ describe("tests FiremittHelper", () => {
       expect(createdIframe.parentNode.removeChild).toHaveBeenCalledWith(createdIframe);
     });
 
+    it("should apply custom dimensions to auto-created iframe", async () => {
+      const createdIframe = {
+        src: "",
+        style: { width: "", height: "" },
+        contentWindow: iframeWin,
+        parentNode: { removeChild: vi.fn() },
+        addEventListener: vi.fn((event: string, handler: () => void) => {
+          if (event === "load") {
+            loadHandler = handler;
+          }
+        }),
+      };
+
+      const container = { appendChild: vi.fn() };
+
+      globalThis.document = {
+        createElement: vi.fn(() => createdIframe),
+      } as unknown as Document;
+
+      const authPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        dim: { width: 800, height: 600 },
+        iframe: { container: container as unknown as HTMLElement },
+      });
+
+      expect(createdIframe.style.width).toBe("800px");
+      expect(createdIframe.style.height).toBe("600px");
+
+      loadHandler!();
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const successMsg = Base64helper.encode({ type: EventType.AuthSucceded, payload: { token: "dim-token" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
+
+      await expect(authPromise).resolves.toBe("dim-token");
+    });
+
+    it("should not set dimensions on a caller-provided iframe element", async () => {
+      const ownedIframe = {
+        ...mockIframe,
+        style: { width: "", height: "" },
+      };
+
+      FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        dim: { width: 800, height: 600 },
+        iframe: { element: ownedIframe as unknown as HTMLIFrameElement },
+      }).catch(() => {});
+
+      expect(ownedIframe.style.width).toBe("");
+      expect(ownedIframe.style.height).toBe("");
+    });
+
     it("should create an iframe inside the container and remove it on failure", async () => {
       const createdIframe = {
         src: "",
+        style: { width: "", height: "" },
         contentWindow: iframeWin,
         parentNode: { removeChild: vi.fn() },
         addEventListener: vi.fn((event: string, handler: () => void) => {
@@ -445,9 +516,154 @@ describe("tests FiremittHelper", () => {
       await expect(authPromise).resolves.toBe("first-settle");
     });
 
+    it("should cancel an active session when a new auth call is made", async () => {
+      const firstIframe = {
+        src: "",
+        style: { width: "", height: "" },
+        contentWindow: iframeWin,
+        parentNode: { removeChild: vi.fn() },
+        addEventListener: vi.fn((event: string, handler: () => void) => {
+          if (event === "load") {
+            loadHandler = handler;
+          }
+        }),
+      };
+
+      const container = { appendChild: vi.fn() };
+
+      globalThis.document = {
+        createElement: vi.fn(() => firstIframe),
+      } as unknown as Document;
+
+      const firstPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { container: container as unknown as HTMLElement },
+      });
+
+      const secondIframe = {
+        src: "",
+        style: { width: "", height: "" },
+        contentWindow: iframeWin,
+        parentNode: { removeChild: vi.fn() },
+        addEventListener: vi.fn(),
+      };
+
+      globalThis.document = {
+        createElement: vi.fn(() => secondIframe),
+      } as unknown as Document;
+
+      const secondPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { container: container as unknown as HTMLElement },
+      });
+
+      await expect(firstPromise).rejects.toThrow("A new authentication session was started.");
+
+      secondPromise.catch(() => {});
+
+      expect(firstIframe.parentNode.removeChild).toHaveBeenCalledWith(firstIframe);
+    });
+
+    it("should not remove a caller-provided element when cancelling an active session", async () => {
+      const firstIframe = {
+        ...mockIframe,
+        style: { width: "", height: "" },
+        parentNode: { removeChild: vi.fn() },
+      };
+
+      const firstPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { element: firstIframe as unknown as HTMLIFrameElement },
+      });
+
+      const secondIframe = {
+        src: "",
+        style: { width: "", height: "" },
+        contentWindow: iframeWin,
+        parentNode: { removeChild: vi.fn() },
+        addEventListener: vi.fn(),
+      };
+
+      const container = { appendChild: vi.fn() };
+
+      globalThis.document = {
+        createElement: vi.fn(() => secondIframe),
+      } as unknown as Document;
+
+      const secondPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { container: container as unknown as HTMLElement },
+      });
+
+      await expect(firstPromise).rejects.toThrow("A new authentication session was started.");
+
+      secondPromise.catch(() => {});
+
+      expect(firstIframe.parentNode.removeChild).not.toHaveBeenCalled();
+    });
+
+    it("should not call the load handler after the session has been cancelled", async () => {
+      let capturedLoadHandler: (() => void) | undefined;
+
+      const cancelledIframe = {
+        src: "",
+        style: { width: "", height: "" },
+        contentWindow: iframeWin,
+        parentNode: { removeChild: vi.fn() },
+        addEventListener: vi.fn((event: string, handler: () => void) => {
+          if (event === "load") {
+            capturedLoadHandler = handler;
+          }
+        }),
+      };
+
+      const container = { appendChild: vi.fn() };
+
+      globalThis.document = {
+        createElement: vi.fn(() => cancelledIframe),
+      } as unknown as Document;
+
+      const firstPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { container: container as unknown as HTMLElement },
+      });
+
+      const secondIframe = {
+        src: "",
+        style: { width: "", height: "" },
+        contentWindow: iframeWin,
+        parentNode: { removeChild: vi.fn() },
+        addEventListener: vi.fn(),
+      };
+
+      globalThis.document = {
+        createElement: vi.fn(() => secondIframe),
+      } as unknown as Document;
+
+      const secondPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { container: container as unknown as HTMLElement },
+      });
+
+      await expect(firstPromise).rejects.toThrow("A new authentication session was started.");
+
+      secondPromise.catch(() => {});
+
+      capturedLoadHandler!();
+
+      expect(iframeWin.postMessage).not.toHaveBeenCalled();
+    });
+
     it("should reject and clean up when contentWindow is null after load", async () => {
       const nullWinIframe = {
         src: "",
+        style: { width: "", height: "" },
         contentWindow: null,
         parentNode: { removeChild: vi.fn() },
         addEventListener: vi.fn((event: string, handler: () => void) => {

--- a/test/firemitt-helper.test.ts
+++ b/test/firemitt-helper.test.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { Base64helper, EventType, FiremittHelper } from "../src/index.ts";
+import { Base64helper, EventType, FiremittHelper, InvalidIframeError } from "../src/index.ts";
 import { VALID_FIREBASE } from "./fixtures.ts";
 
 
@@ -32,7 +32,7 @@ describe("tests FiremittHelper", () => {
     } as unknown as Window & typeof globalThis;
   });
 
-  describe("auth", () => {
+  describe("auth (popup mode)", () => {
     it("should resolve with token on successful authentication", async () => {
       const authPromise = FiremittHelper.auth(BASE_OPTIONS);
 
@@ -215,6 +215,265 @@ describe("tests FiremittHelper", () => {
       messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
 
       await expect(authPromise).resolves.toBe("retry-token");
+    });
+  });
+
+  describe("auth (iframe mode)", () => {
+    let iframeWin: { postMessage: ReturnType<typeof vi.fn> };
+    let mockIframe: {
+      src: string;
+      contentWindow: typeof iframeWin;
+      parentNode: { removeChild: ReturnType<typeof vi.fn> } | null;
+      addEventListener: ReturnType<typeof vi.fn>;
+    };
+    let loadHandler: (() => void) | undefined;
+
+    beforeEach(() => {
+      iframeWin = { postMessage: vi.fn() };
+      loadHandler = undefined;
+
+      mockIframe = {
+        src: "",
+        contentWindow: iframeWin,
+        parentNode: { removeChild: vi.fn() },
+        addEventListener: vi.fn((event: string, handler: () => void) => {
+          if (event === "load") {
+            loadHandler = handler;
+          }
+        }),
+      };
+
+      (globalThis.window as unknown as {
+        addEventListener: ReturnType<typeof vi.fn>;
+      }).addEventListener = vi.fn((_, handler: (e: MessageEvent) => void) => {
+        messageListeners.push(handler);
+      });
+    });
+
+    it("should throw InvalidIframeError when neither element nor container is given", () => {
+      expect(() =>
+        FiremittHelper.auth({ ...BASE_OPTIONS, mode: "iframe" }),
+      ).toThrow(InvalidIframeError);
+    });
+
+    it("should resolve with token using a provided iframe element", async () => {
+      const authPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { element: mockIframe as unknown as HTMLIFrameElement },
+      });
+
+      expect(mockIframe.src).toBe("https://fireguard-instance.com/");
+
+      loadHandler!();
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const successMsg = Base64helper.encode({ type: EventType.AuthSucceded, payload: { token: "iframe-token" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
+
+      await expect(authPromise).resolves.toBe("iframe-token");
+    });
+
+    it("should reject on AuthFailed when using a provided iframe element", async () => {
+      const authPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { element: mockIframe as unknown as HTMLIFrameElement },
+      });
+
+      loadHandler!();
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const failMsg = Base64helper.encode({ type: EventType.AuthFailed, payload: { error: "iframe_error" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: failMsg } as MessageEvent));
+
+      await expect(authPromise).rejects.toBe("iframe_error");
+    });
+
+    it("should reject on Closed event when using a provided iframe element", async () => {
+      const authPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { element: mockIframe as unknown as HTMLIFrameElement },
+      });
+
+      loadHandler!();
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const closedMsg = Base64helper.encode({ type: EventType.Closed, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: closedMsg } as MessageEvent));
+
+      await expect(authPromise).rejects.toThrow("The authentication window was closed.");
+    });
+
+    it("should not remove a caller-provided iframe element on settle", async () => {
+      const authPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { element: mockIframe as unknown as HTMLIFrameElement },
+      });
+
+      loadHandler!();
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const successMsg = Base64helper.encode({ type: EventType.AuthSucceded, payload: { token: "no-remove-token" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
+
+      await expect(authPromise).resolves.toBe("no-remove-token");
+
+      expect((mockIframe.parentNode as { removeChild: ReturnType<typeof vi.fn> }).removeChild).not.toHaveBeenCalled();
+    });
+
+    it("should create an iframe inside the container and remove it on success", async () => {
+      const createdIframe = {
+        src: "",
+        contentWindow: iframeWin,
+        parentNode: { removeChild: vi.fn() },
+        addEventListener: vi.fn((event: string, handler: () => void) => {
+          if (event === "load") {
+            loadHandler = handler;
+          }
+        }),
+      };
+
+      const container = { appendChild: vi.fn() };
+
+      globalThis.document = {
+        createElement: vi.fn(() => createdIframe),
+      } as unknown as Document;
+
+      const authPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { container: container as unknown as HTMLElement },
+      });
+
+      expect(container.appendChild).toHaveBeenCalledWith(createdIframe);
+      expect(createdIframe.src).toBe("https://fireguard-instance.com/");
+
+      loadHandler!();
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const successMsg = Base64helper.encode({ type: EventType.AuthSucceded, payload: { token: "container-token" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
+
+      await expect(authPromise).resolves.toBe("container-token");
+
+      expect(createdIframe.parentNode.removeChild).toHaveBeenCalledWith(createdIframe);
+    });
+
+    it("should create an iframe inside the container and remove it on failure", async () => {
+      const createdIframe = {
+        src: "",
+        contentWindow: iframeWin,
+        parentNode: { removeChild: vi.fn() },
+        addEventListener: vi.fn((event: string, handler: () => void) => {
+          if (event === "load") {
+            loadHandler = handler;
+          }
+        }),
+      };
+
+      const container = { appendChild: vi.fn() };
+
+      globalThis.document = {
+        createElement: vi.fn(() => createdIframe),
+      } as unknown as Document;
+
+      const authPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { container: container as unknown as HTMLElement },
+      });
+
+      loadHandler!();
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const failMsg = Base64helper.encode({ type: EventType.AuthFailed, payload: { error: "container-fail" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: failMsg } as MessageEvent));
+
+      await expect(authPromise).rejects.toBe("container-fail");
+
+      expect(createdIframe.parentNode.removeChild).toHaveBeenCalledWith(createdIframe);
+    });
+
+    it("should ignore a second settle attempt in iframe mode (double-settle guard)", async () => {
+      const authPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { element: mockIframe as unknown as HTMLIFrameElement },
+      });
+
+      loadHandler!();
+
+      const loadedMsg = Base64helper.encode({ type: EventType.Loaded, payload: {} });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: loadedMsg } as MessageEvent));
+
+      const successMsg = Base64helper.encode({ type: EventType.AuthSucceded, payload: { token: "first-settle" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: successMsg } as MessageEvent));
+
+      const failMsg = Base64helper.encode({ type: EventType.AuthFailed, payload: { error: "late-settle" } });
+
+      messageListeners.forEach(h => h({ isTrusted: true, data: failMsg } as MessageEvent));
+
+      await expect(authPromise).resolves.toBe("first-settle");
+    });
+
+    it("should reject and clean up when contentWindow is null after load", async () => {
+      const nullWinIframe = {
+        src: "",
+        contentWindow: null,
+        parentNode: { removeChild: vi.fn() },
+        addEventListener: vi.fn((event: string, handler: () => void) => {
+          if (event === "load") {
+            loadHandler = handler;
+          }
+        }),
+      };
+
+      const container = { appendChild: vi.fn() };
+
+      globalThis.document = {
+        createElement: vi.fn(() => nullWinIframe),
+      } as unknown as Document;
+
+      const authPromise = FiremittHelper.auth({
+        ...BASE_OPTIONS,
+        mode: "iframe",
+        iframe: { container: container as unknown as HTMLElement },
+      });
+
+      loadHandler!();
+
+      await expect(authPromise).rejects.toThrow("Could not access the iframe window.");
+
+      expect(nullWinIframe.parentNode.removeChild).toHaveBeenCalledWith(nullWinIframe);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds the ability to embed Fireguard inside an `<iframe>` as an alternative to the existing popup window flow. The popup mode is fully preserved and unchanged. Iframe mode is opt-in via a new `mode` option.

## Changes

### New: `mode` option

Pass `mode: "iframe"` to `FiremittHelper.auth()` alongside an `iframe` option to use embedded mode:

```ts
// Auto-create an iframe inside a container
await FiremittHelper.auth({
  url: "https://fireguard.example.com",
  config: { ... },
  mode: "iframe",
  iframe: { container: document.getElementById("auth-container")! },
});

// Reuse an existing iframe element
await FiremittHelper.auth({
  url: "https://fireguard.example.com",
  config: { ... },
  mode: "iframe",
  iframe: { element: document.querySelector("iframe")! },
});
```

### Auto-managed iframes

When a `container` is provided, Firemitt creates the iframe, appends it to the container, applies dimensions from the `dim` option, and removes it automatically when the auth flow settles (success or failure).

### Session deduplication

Calling `auth()` in iframe mode while a previous session is still active immediately cancels the old session, removes the old iframe (if owned), and starts fresh.

### Dimensions applied to auto-created iframes

The `dim.width` and `dim.height` options (defaulting to `450×260`) are applied as inline `width`/`height` styles on auto-created iframes. Caller-provided elements are left unstyled.

### `InvalidIframeError`

Thrown when `mode: "iframe"` is used but neither `element` nor `container` is provided.

### `EventHelper` host-window capture

`EventHelper.init()` now captures the calling page's `window` at initialization time and uses it for all `addEventListener`/`removeEventListener` calls, preventing cross-origin access errors when the library runs in an iframe context.

### Foreign message tolerance

`EventHelper.on()` now silently ignores messages that cannot be decoded as Firemitt base64-encoded payloads (e.g. Firebase OAuth internal messages, browser extension messages).

### Playground scenarios

Three new scenarios in the playground:

- **Iframe embed (auto-create)** — auto-created iframe inside the result panel
- **Iframe embed (dialog)** — auto-created iframe inside a centered modal `<dialog>`
- **Iframe embed (existing element)** — reuses a persistent `<iframe>` already in the DOM

## API

```ts
type TIframeOptions =
  | { element: HTMLIFrameElement; container?: never }
  | { container: HTMLElement; element?: never };

type TFiremittOptions = {
  url: string;
  mode?: "popup" | "iframe";
  iframe?: TIframeOptions;
  dim?: { width?: number; height?: number };
  pos?: { x?: number; y?: number };
  config?: Partial<TFireguardOptions>;
};
```

## Tests

- `InvalidIframeError` thrown when no element or container is given
- Iframe mode resolves with token on `AuthSucceded`
- Iframe mode rejects on `AuthFailed`
- Iframe mode rejects on `Closed`
- Auto-created iframe has dimensions applied
- Caller-provided iframe is not resized
- Caller-provided iframe is not removed on settle
- Auto-created iframe is removed on settle (success and failure)
- Active session is cancelled when `auth()` is called again
- Caller-provided element is not removed when cancelling an active session
- `load` handler is skipped after session cancellation
- `null` contentWindow is rejected and cleaned up
- Foreign/malformed messages are silently ignored

**Coverage: 100% statements, branches, functions, lines**
